### PR TITLE
Change imports of svelte-fontawesome in examples

### DIFF
--- a/examples/svelte-app-typescript/src/App.svelte
+++ b/examples/svelte-app-typescript/src/App.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { FontAwesomeIcon } from '@seantimm/svelte-fontawesome';
+  import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
 
   // Importing types from the API library along with other exports
   import {

--- a/examples/svelte-app/src/App.svelte
+++ b/examples/svelte-app/src/App.svelte
@@ -1,8 +1,6 @@
 <script>
-  import { FontAwesomeIcon } from '@seantimm/svelte-fontawesome';
-  import {
-  faCoffee
-} from '@fortawesome/free-solid-svg-icons'
+  import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome';
+  import { faCoffee } from '@fortawesome/free-solid-svg-icons'
 </script>
 
 <div id="app">

--- a/examples/sveltekit-app/src/routes/index.svelte
+++ b/examples/sveltekit-app/src/routes/index.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { FontAwesomeIcon } from '@seantimm/svelte-fontawesome'
+  import { FontAwesomeIcon } from '@fortawesome/svelte-fontawesome'
   import { faThumbsUp } from '@fortawesome/free-solid-svg-icons'
   import { config } from '@fortawesome/fontawesome-svg-core'
 


### PR DESCRIPTION
The import statements in the examples were still referencing the old package paths.