### PR TITLE
Fix SvelteKit v2 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "version": "0.2.0",
   "type": "module",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "src/index.js"
+    }
+  },
   "main": "index.js",
   "module": "index.es.js",
   "jsnext:main": "index.es.js",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "svelte": "src/index.js",
   "exports": {
     ".": {
-      "svelte": "src/index.js"
+      "svelte": "./src/index.js"
     }
   },
   "main": "index.js",


### PR DESCRIPTION
Fix deprecation warning when running SvelteKit v2 `npm run dev`.

Details: https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition