### PR TITLE
Add exports condition for svelte

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "version": "0.2.0",
   "type": "module",
   "svelte": "src/index.js",
+  "exports": {
+    ".": {
+      "svelte": "./src/index.js"
+    }
+  },
   "main": "index.js",
   "module": "index.es.js",
   "jsnext:main": "index.es.js",


### PR DESCRIPTION
Currently, using this library with vite 5.0.x and @sveltejs/kit 2.0.x will display the following warning:

```
11:16:46 AM [vite-plugin-svelte] WARNING: The following packages have a svelte field in their package.json but no exports condition for svelte.

@fortawesome/svelte-fontawesome@0.2.0

Please see https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition for details.
```

According to https://github.com/sveltejs/vite-plugin-svelte/blob/main/docs/faq.md#missing-exports-condition, the `svelte` key in `package.json` is deprecated at vite-plugin-svelte 3.x and it seems that it should use `exports` key instead.